### PR TITLE
Fix a bug that deploy pr messages trigger other actions also

### DIFF
--- a/lib/ruboty/github/actions/create_pull_request.rb
+++ b/lib/ruboty/github/actions/create_pull_request.rb
@@ -8,6 +8,9 @@ module Ruboty
           else
             require_access_token
           end
+          # Action handlers should return truthy value to tell ruboty that the given message has been handled.
+          # Otherwise, ruboty tries to execute other handlers.
+          true
         end
 
         private


### PR DESCRIPTION
This PR fixes a bug that the message `@qiitan deploy pull request ...` triggers other actions (such as [ruboty-talk](https://github.com/r7kamura/ruboty-talk) actions) in addition to the pull request action.

<img width="430" alt="qiitan" src="https://user-images.githubusercontent.com/1477130/42015240-7b283c8e-7ae1-11e8-9f38-83ab8ee5256c.png">

(In this conversation, Ruboty creates deploy pull request in reply to my message. However, [ruboty-talk](https://github.com/r7kamura/ruboty-talk)'s handler is also executed and a reply message is sent.)

The reason why other actions are triggered is that Ruboty judges the given message is not matched to the action if the handler of the action returns falsy value and Ruboty tries to call other handlers.
We modify `Ruboty::Github::Actions::CreatePullRequest#call` to always return truthy value to tell Ruboty the given message is matched and handled.

## References

- Implementation of processing handlers
  - https://github.com/r7kamura/ruboty/blob/69b89b0f46d9404c142d78d4e82e2d90b05a2248/lib/ruboty/handlers/base.rb#L32
  - https://github.com/r7kamura/ruboty/blob/69b89b0f46d9404c142d78d4e82e2d90b05a2248/lib/ruboty/robot.rb#L29
