### PR TITLE
Add AFTER_MERGE_MESSAGE env variable to customize the message after merge

### DIFF
--- a/lib/ruboty/github/actions/merge_pull_request.rb
+++ b/lib/ruboty/github/actions/merge_pull_request.rb
@@ -8,11 +8,17 @@ module Ruboty
 
         def close
           request
-          message.reply("Merged #{issue.html_url}")
+          after_merge_message
         end
 
         def request
           client.merge_pull_request(repository, issue_number)
+        end
+
+        def after_merge_message
+          message.reply("Merged #{issue.html_url}")
+          custom_message = ENV.fetch('AFTER_MERGE_MESSAGE', nil)
+          message.reply(custom_message) if custom_message
         end
       end
     end


### PR DESCRIPTION
## What
Implemented the after_merge_message method in Ruboty::Actions::MergePullRequest

- In addition to the message that was displayed after merging, it is now possible to send a customized message.
- This allows for commanding ruboty to perform post-merge processes.