### PR TITLE
Fix custom message handling logic

### DIFF
--- a/lib/ruboty/github/actions/merge_pull_request.rb
+++ b/lib/ruboty/github/actions/merge_pull_request.rb
@@ -17,8 +17,13 @@ module Ruboty
 
         def after_merge_message
           message.reply("Merged #{issue.html_url}")
+
           custom_message = ENV.fetch('AFTER_MERGE_MESSAGE', nil)
-          message.reply(custom_message) if custom_message
+          target_repository = ENV.fetch('AFTER_MERGE_MESSAGE_TARGET_REPOSITORY', '')
+
+          return unless (repository == target_repository) && custom_message
+
+          message.reply(custom_message)
         end
       end
     end


### PR DESCRIPTION
- Added a condition to execute custom_message based on the specified repository.
- The behavior needs to change for each repository because we want it to act differently depending on the repository.