### PR TITLE
Bump Ruby version on ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.2", "3.3", "3.4"]
     runs-on: "ubuntu-latest"
     continue-on-error: false
     steps:
@@ -32,6 +32,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       - run: bundle exec rubocop

--- a/spec/ruboty/handlers/github_spec.rb
+++ b/spec/ruboty/handlers/github_spec.rb
@@ -81,7 +81,7 @@ describe Ruboty::Handlers::Github do
       %(ruboty create issue "#{title}" on #{user}/#{repository})
     end
 
-    include_examples 'requires access token without access token'
+    it_behaves_like 'requires access token without access token'
 
     context 'with access token' do
       it 'creates a new issue with given title on given repository' do
@@ -115,7 +115,7 @@ describe Ruboty::Handlers::Github do
       %(ruboty search issues "#{query}")
     end
 
-    include_examples 'requires access token without access token'
+    it_behaves_like 'requires access token without access token'
 
     context 'with access token' do
       it 'search an issue with given query' do
@@ -169,7 +169,7 @@ describe Ruboty::Handlers::Github do
       1
     end
 
-    include_examples 'requires access token without access token'
+    it_behaves_like 'requires access token without access token'
 
     context 'with closed issue' do
       it 'replies so' do


### PR DESCRIPTION
# What

Close https://github.com/increments/ruboty-qiita-github/issues/12

- Bump ruby version on ci
- and autocorrect by rubocop

# Refs

- https://www.ruby-lang.org/en/downloads/branches/

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
