### PR TITLE
Remove codeclimate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ruboty::Github
-[![Gem Version](https://badge.fury.io/rb/ruboty-qiita-github.svg)](https://badge.fury.io/rb/ruboty-qiita-github) [![Test](https://github.com/increments/ruboty-qiita-github/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/increments/ruboty-qiita-github/actions/workflows/test.yml) [![Maintainability](https://api.codeclimate.com/v1/badges/764bf9dc5796f0d3bef3/maintainability)](https://codeclimate.com/github/increments/ruboty-qiita-github/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/764bf9dc5796f0d3bef3/test_coverage)](https://codeclimate.com/github/increments/ruboty-qiita-github/test_coverage)
+[![Gem Version](https://badge.fury.io/rb/ruboty-qiita-github.svg)](https://badge.fury.io/rb/ruboty-qiita-github) [![Test](https://github.com/increments/ruboty-qiita-github/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/increments/ruboty-qiita-github/actions/workflows/test.yml)
 
 Manage GitHub via Ruboty.
 This gem adds `deploy pull request` command to original ruboty-github plugin.


### PR DESCRIPTION
## What

- Remove codeclimate badge from README

## Why

- Code Climate API was disabled
    - https://docs.qlty.sh/migration/guide