### PR TITLE
Fix ISSUE_PATTERN to handle Slack URL formats

### DIFF
--- a/lib/ruboty/handlers/github.rb
+++ b/lib/ruboty/handlers/github.rb
@@ -3,7 +3,7 @@
 module Ruboty
   module Handlers
     class Github < Base
-      ISSUE_PATTERN = %r{(?:https?://[^/]+/)?(?<repo>.+)(?:#|/pull/|/issues/)(?<number>\d+) ?}.freeze
+      ISSUE_PATTERN = %r{<?(?:https?://[^/]+/|[^/]+\.[^/]+/)?(?<repo>[^/]+/[^/]+)(?:#|/pull/|/issues/)(?<number>\d+)>? ?}.freeze
 
       env :GITHUB_BASE_URL, 'Pass GitHub URL if needed (e.g. https://github.example.com)', optional: true
 

--- a/spec/ruboty/handlers/github_spec.rb
+++ b/spec/ruboty/handlers/github_spec.rb
@@ -125,6 +125,55 @@ describe Ruboty::Handlers::Github do
     end
   end
 
+  describe 'ISSUE_PATTERN' do
+    subject(:match) { described_class::ISSUE_PATTERN.match(input) }
+
+    context 'with owner/repo#number format' do
+      let(:input) { 'alice/test#123' }
+
+      it 'extracts repo and number' do
+        expect(match[:repo]).to eq('alice/test')
+        expect(match[:number]).to eq('123')
+      end
+    end
+
+    context 'with full URL using /issues/' do
+      let(:input) { 'https://github.com/alice/test/issues/123' }
+
+      it 'extracts repo and number' do
+        expect(match[:repo]).to eq('alice/test')
+        expect(match[:number]).to eq('123')
+      end
+    end
+
+    context 'with full URL using /pull/' do
+      let(:input) { 'https://github.com/alice/test/pull/123' }
+
+      it 'extracts repo and number' do
+        expect(match[:repo]).to eq('alice/test')
+        expect(match[:number]).to eq('123')
+      end
+    end
+
+    context 'with protocol-stripped URL (Slack display text)' do
+      let(:input) { 'github.com/alice/test/pull/123' }
+
+      it 'extracts repo and number' do
+        expect(match[:repo]).to eq('alice/test')
+        expect(match[:number]).to eq('123')
+      end
+    end
+
+    context 'with angle-bracketed URL' do
+      let(:input) { '<https://github.com/alice/test/pull/123>' }
+
+      it 'extracts repo and number' do
+        expect(match[:repo]).to eq('alice/test')
+        expect(match[:number]).to eq('123')
+      end
+    end
+  end
+
   describe '#close_issue' do
     before do
       stub_request(:get, "https://api.github.com/repos/#{user}/#{repository}/issues/#{issue_number}")
@@ -180,6 +229,39 @@ describe Ruboty::Handlers::Github do
 
     context 'with access token' do
       it 'closes specified issue' do
+        call
+      end
+    end
+
+    context 'with full URL format' do
+      let(:body) do
+        "@ruboty close https://github.com/#{user}/#{repository}/issues/#{issue_number}"
+      end
+
+      it 'closes specified issue' do
+        expect(robot).to receive(:say).with(hash_including(body: "Closed #{html_url}"))
+        call
+      end
+    end
+
+    context 'with protocol-stripped URL format (Slack display text)' do
+      let(:body) do
+        "@ruboty close github.com/#{user}/#{repository}/issues/#{issue_number}"
+      end
+
+      it 'closes specified issue' do
+        expect(robot).to receive(:say).with(hash_including(body: "Closed #{html_url}"))
+        call
+      end
+    end
+
+    context 'with angle-bracketed URL format' do
+      let(:body) do
+        "@ruboty close <https://github.com/#{user}/#{repository}/issues/#{issue_number}>"
+      end
+
+      it 'closes specified issue' do
+        expect(robot).to receive(:say).with(hash_including(body: "Closed #{html_url}"))
         call
       end
     end


### PR DESCRIPTION
## What

Closes #58

## Why

<!-- See issue -->

## How

Handle domain-without-protocol (`github.com/owner/repo/pull/123`) via an alternative pattern `[^/]+\.[^/]+/` alongside the existing `https?://[^/]+/`.
This pattern only matches strings containing a dot (`.`), so it won't consume `owner/` in `owner/repo#123` as a domain (GitHub usernames cannot contain dots).

### Non Goal

- Handling Slack's `<url|text>` pipe format is out of scope — the adapter layer parses it and passes only the display text to the handler

## Refs

- [Slack URL formatting](https://api.slack.com/reference/surfaces/formatting#linking-urls)
