### PR TITLE
Add GitHub Actions workflow for gem release via Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0


### PR DESCRIPTION
## What

Closes #60

## Why

<!-- See issue -->

## How

- Adopted the same structure as qiita-markdown's [release.yml](https://github.com/increments/qiita-markdown/blob/master/.github/workflows/release.yml)
- Pinned `actions/checkout` and `ruby/setup-ruby` SHAs to match the existing `test.yml`

### Out of scope

- Trusted Publisher configuration on rubygems.org (see issue TODO)
- Creating `release` environment on GitHub

## Refs

<!-- See issue -->
